### PR TITLE
Update BContactsViewController.m

### DIFF
--- a/ChatUI/Classes/Components/View Controllers/BContactsViewController.m
+++ b/ChatUI/Classes/Components/View Controllers/BContactsViewController.m
@@ -114,6 +114,9 @@
     // We want to create an action sheet which will allow users to choose how they add their contacts
     UIAlertController * view = [UIAlertController alertControllerWithTitle:[NSBundle t:bSearch] message:Nil preferredStyle:UIAlertControllerStyleActionSheet];
     
+    // Fix for iPad contacts load (Added by wazowski78 at 17/03/2017)
+    view.popoverPresentationController.barButtonItem = self.navigationItem.rightBarButtonItem;
+
 #ifdef ChatSDKContactBookModule
     UIAlertAction * phoneBook = [UIAlertAction actionWithTitle:[NSBundle t:bPhonebook]
                                                          style:UIAlertActionStyleDefault


### PR DESCRIPTION
I am receiving this a crash when running the app in an iPad.

```
2017-03-15 17:13:42.898 HeyYapp[1552:390067] *** Terminating app due to uncaught exception 'NSGenericException', reason: 'Your application has presented a UIAlertController (<UIAlertController: 0x1592bc00>) of style UIAlertControllerStyleActionSheet. The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.'
*** First throw call stack:
(0x248fb91b 0x24096e17 0x29767485 0x291c7e93 0x291c5db3 0x2911f4c9 0x2912b7db 0x28e69b1d 0x248bd6c9 0x248bb9cd 0x248bbdff 0x2480b229 0x2480b015 0x25dfbac9 0x28edf189 0xc5de9 0x244b3873)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

The problem seems to be the way the uialert is showed so it has to be changed to popover using this method: UIModalPresentationPopover

I have fixed this issue adding this line of code at BContactsViewController:

```
-(void) addContacts {
    
    __weak BContactsViewController * weakSelf = self;
    
    // We want to create an action sheet which will allow users to choose how they add their contacts
    UIAlertController * view = [UIAlertController alertControllerWithTitle:[NSBundle t:bSearch] message:Nil preferredStyle:UIAlertControllerStyleActionSheet];
    // *** Edited
    view.popoverPresentationController.barButtonItem = self.navigationItem.rightBarButtonItem;
    // ***
```